### PR TITLE
Fix error in opening bag file due to unset storage options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Inverse dynamics solver
 
+[![License](https://img.shields.io/badge/License-BSD_3--Clause-red.svg?style=plastic)](https://opensource.org/licenses/BSD-3-Clause)
+[![Build Status](https://build.ros2.org/buildStatus/icon?job=Hdev__inverse_dynamics_solver__ubuntu_jammy_amd64&style=plastic)](https://build.ros2.org/job/Hdev__inverse_dynamics_solver__ubuntu_jammy_amd64/)
+[![Static Badge](https://img.shields.io/badge/Open_in-Code_Ocean-blue?style=plastic)](https://doi.org/10.24433/CO.2265930.v1)
+
 This is the accompanying code of the paper
 
 > V. Petrone, E. Ferrentino, P. Chiacchio, "A ROS2-based software library for inverse dynamics computation". Under peer-review.
@@ -42,6 +46,8 @@ pip install -r requirements.txt
 The dependencies are installed in the virtual environment called [`venv`](./venv/): to deactivate it, simply run `deactivate` in your terminal.
 
 ## Reproducible results
+
+[![Static Badge](https://img.shields.io/badge/Open_in-Code_Ocean-blue?style=plastic)](https://doi.org/10.24433/CO.2265930.v1)
 
 Our results are reproducible via the demos provided in the packages above, or by running the CodeOcean capsule: the latter option does not require installing any dependency on your computer.
 The capsule is reachable at [https://doi.org/10.24433/CO.2265930.v1](https://doi.org/10.24433/CO.2265930.v1).

--- a/ur10_inverse_dynamics_solver/package.xml
+++ b/ur10_inverse_dynamics_solver/package.xml
@@ -22,6 +22,8 @@
   <test_depend>rclcpp</test_depend>
   <test_depend>ros_testing</test_depend>
   <test_depend>rosbag2_cpp</test_depend>
+  <test_depend>rosbag2_storage</test_depend>
+  <test_depend>rosbag2_storage_default_plugins</test_depend>
   <test_depend>trajectory_msgs</test_depend>
 
   <export>

--- a/ur10_inverse_dynamics_solver/test/test_ur10_inverse_dynamics_solver.cpp
+++ b/ur10_inverse_dynamics_solver/test/test_ur10_inverse_dynamics_solver.cpp
@@ -17,6 +17,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp/serialization.hpp>
 #include <rosbag2_cpp/reader.hpp>
+#include <rosbag2_storage/storage_options.hpp>
 #include <trajectory_msgs/msg/joint_trajectory.hpp>
 
 // PluginLib
@@ -134,7 +135,10 @@ TEST_F(InverseDynamicsSolverUR10Test, TestDynamicParameters)
   rclcpp::Serialization<trajectory_msgs::msg::JointTrajectory> serialization;
   RCLCPP_INFO(node->get_logger(), "Opening '%s'", bag_filename.c_str());
   rosbag2_cpp::Reader reader;
-  reader.open(bag_filename);
+  rosbag2_storage::StorageOptions storage_options;
+  storage_options.uri = bag_filename;
+  storage_options.storage_id = "sqlite3";
+  reader.open(storage_options);
 
   // For each trajectory in the rosbag file, evaluate the dynamics solver
   while (reader.has_next())


### PR DESCRIPTION
This PR solves build issues raised using the Jenkins system, according to the ROS2 build farm policies.

Sources:
- [Instructions](https://github.com/ros-infrastructure/ros_buildfarm/blob/master/doc/index.rst#run-jobs-locally) to build and test with Jenkins locally
- [Index file](https://raw.githubusercontent.com/ros2/ros_buildfarm_config/refs/heads/ros2/index.yaml) used to retrieve this repo from `rosdistro` (please see the step above to know how to use it)

Side notes:
- Jenkins requires a GH access token with `repo:read` permissions: this is needed to [setup Jenkins on your local machine](https://github.com/ros-infrastructure/ros_buildfarm/blob/master/doc/environment.rst#provide-credentials-for-jenkins-master)