### PR TITLE
bugfix/realtime_safeness

### DIFF
--- a/franka_inria_inverse_dynamics_solver/CMakeLists.txt
+++ b/franka_inria_inverse_dynamics_solver/CMakeLists.txt
@@ -13,6 +13,12 @@ if(CMAKE_COMPILER_IS_GNUCXX
   )
 endif()
 
+# Code optimization flags are available here
+# https://clang.llvm.org/docs/CommandGuide/clang.html#code-generation-options
+set(CMAKE_CXX_FLAGS
+    "-O3"
+)
+
 # find dependencies
 find_package(ament_cmake REQUIRED)
 

--- a/franka_inria_inverse_dynamics_solver/src/franka_inria_inverse_dynamics_solver.cpp
+++ b/franka_inria_inverse_dynamics_solver/src/franka_inria_inverse_dynamics_solver.cpp
@@ -20,8 +20,9 @@
 #include "franka_inria_inverse_dynamics_solver/get_FrictionTorque.hpp"
 #include "franka_inria_inverse_dynamics_solver/franka_inria_inverse_dynamics_solver.hpp"
 
-using namespace franka_inria_inverse_dynamics_solver;
+namespace franka_inria_inverse_dynamics_solver
 
+{
 void InverseDynamicsSolverFrankaInria::initialize(rclcpp::node_interfaces::NodeParametersInterface::ConstSharedPtr, const std::string&,
                                                   const std::string&)
 {}
@@ -53,6 +54,7 @@ Eigen::VectorXd InverseDynamicsSolverFrankaInria::getTorques(const Eigen::Vector
   return inverse_dynamics_solver::InverseDynamicsSolver::getTorques(joint_positions, joint_velocities, joint_accelerations) +
          getFrictionVector(joint_velocities);
 }
+}  // namespace franka_inria_inverse_dynamics_solver
 
 #include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(franka_inria_inverse_dynamics_solver::InverseDynamicsSolverFrankaInria, inverse_dynamics_solver::InverseDynamicsSolver)

--- a/inverse_dynamics_solver/demo/evaluate_solver.cpp
+++ b/inverse_dynamics_solver/demo/evaluate_solver.cpp
@@ -114,15 +114,15 @@ public:
       Eigen::VectorXd torques = solver_->getTorques(positions, velocities, accelerations[i]);
       const std::chrono::steady_clock::time_point t_end = std::chrono::steady_clock::now();
       const double elapsed_ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
-      avg_time_ms += (elapsed_ms - avg_time_ms) / ++sample_count;
-      max_time_ms = std::max(max_time_ms, elapsed_ms);
+      avg_time_ms_ += (elapsed_ms - avg_time_ms_) / ++sample_count_;
+      max_time_ms_ = std::max(max_time_ms_, elapsed_ms);
 
       writer.write(joint_states[i], topic + "_gt", timestamps[i]);
       sensor_msgs::msg::JointState output_msg = joint_states[i];
       output_msg.effort.assign(torques.data(), torques.data() + torques.size());
       writer.write(output_msg, topic, timestamps[i]);
     }
-    RCLCPP_INFO(this->get_logger(), "getTorques execution time: avg = %.6f, max = %.6f (%zu samples) [ms]", avg_time_ms, max_time_ms, sample_count);
+    RCLCPP_INFO(this->get_logger(), "getTorques execution time: avg = %.6f, max = %.6f (%zu samples) [ms]", avg_time_ms_, max_time_ms_, sample_count_);
   }
 
 private:
@@ -250,9 +250,9 @@ private:
     }
   }
 
-  double avg_time_ms{ 0.0 };
-  double max_time_ms{ 0.0 };
-  std::size_t sample_count{ 0 };
+  double avg_time_ms_{ 0.0 };
+  double max_time_ms_{ 0.0 };
+  std::size_t sample_count_{ 0 };
   std::unique_ptr<InverseDynamicsSolverLoader> solver_loader_;
   std::shared_ptr<inverse_dynamics_solver::InverseDynamicsSolver> solver_;
   std::vector<std::string> ordered_joint_names_;

--- a/inverse_dynamics_solver/demo/evaluate_solver.cpp
+++ b/inverse_dynamics_solver/demo/evaluate_solver.cpp
@@ -16,6 +16,7 @@
  * -------------------------------------------------------------------
  */
 
+#include <chrono>
 #include <memory>
 #include <string>
 #include <vector>
@@ -61,7 +62,7 @@ public:
     }
   }
 
-  void processBag() const
+  void processBag()
   {
     // Read parameters
     std::string input_bag = this->get_parameter("input_bag").as_string();
@@ -108,13 +109,20 @@ public:
     {
       Eigen::VectorXd positions = Eigen::Map<const Eigen::VectorXd>(joint_states[i].position.data(), joint_states[i].position.size());
       Eigen::VectorXd velocities = Eigen::Map<const Eigen::VectorXd>(joint_states[i].velocity.data(), joint_states[i].velocity.size());
+
+      const std::chrono::steady_clock::time_point t_start = std::chrono::steady_clock::now();
       Eigen::VectorXd torques = solver_->getTorques(positions, velocities, accelerations[i]);
+      const std::chrono::steady_clock::time_point t_end = std::chrono::steady_clock::now();
+      const double elapsed_ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
+      avg_time_ms += (elapsed_ms - avg_time_ms) / ++sample_count;
+      max_time_ms = std::max(max_time_ms, elapsed_ms);
 
       writer.write(joint_states[i], topic + "_gt", timestamps[i]);
       sensor_msgs::msg::JointState output_msg = joint_states[i];
       output_msg.effort.assign(torques.data(), torques.data() + torques.size());
       writer.write(output_msg, topic, timestamps[i]);
     }
+    RCLCPP_INFO(this->get_logger(), "getTorques execution time: avg = %.6f, max = %.6f (%zu samples) [ms]", avg_time_ms, max_time_ms, sample_count);
   }
 
 private:
@@ -242,6 +250,9 @@ private:
     }
   }
 
+  double avg_time_ms{ 0.0 };
+  double max_time_ms{ 0.0 };
+  std::size_t sample_count{ 0 };
   std::unique_ptr<InverseDynamicsSolverLoader> solver_loader_;
   std::shared_ptr<inverse_dynamics_solver::InverseDynamicsSolver> solver_;
   std::vector<std::string> ordered_joint_names_;

--- a/kdl_inverse_dynamics_solver/include/kdl_inverse_dynamics_solver/kdl_inverse_dynamics_solver.hpp
+++ b/kdl_inverse_dynamics_solver/include/kdl_inverse_dynamics_solver/kdl_inverse_dynamics_solver.hpp
@@ -78,7 +78,7 @@ private:
    */
   void verifyInitialization_() const;
 
-  bool initialized_ = false;
+  bool initialized_{ false };
   unsigned int number_of_joints_;
   KDL::Chain chain_;
   std::unique_ptr<KDL::ChainDynParam> solver_;

--- a/kdl_inverse_dynamics_solver/include/kdl_inverse_dynamics_solver/kdl_inverse_dynamics_solver.hpp
+++ b/kdl_inverse_dynamics_solver/include/kdl_inverse_dynamics_solver/kdl_inverse_dynamics_solver.hpp
@@ -83,13 +83,13 @@ private:
   KDL::Chain chain_;
   std::unique_ptr<KDL::ChainDynParam> solver_;
 
-  // Kinematic/dynamic variables are allocated in the `initialize` method for real-time safeness; they are declared with smart pointers because all
-  // the methods in this class are `const`, and this would not allow changing their values if they were not declared with pointers
-  std::unique_ptr<KDL::JntArray> kdl_joint_positions_;
-  std::unique_ptr<KDL::JntArray> kdl_joint_velocities_;
-  std::unique_ptr<KDL::JntSpaceInertiaMatrix> H_;
-  std::unique_ptr<KDL::JntArray> c_;
-  std::unique_ptr<KDL::JntArray> g_;
+  // These variables are stack-allocated in the initialize method for real-time safeness: they are declared as mutable as they are either a wrapper
+  // for input variables, or output variables
+  mutable KDL::JntArray kdl_joint_positions_;
+  mutable KDL::JntArray kdl_joint_velocities_;
+  mutable KDL::JntSpaceInertiaMatrix H_;
+  mutable KDL::JntArray c_;
+  mutable KDL::JntArray g_;
   Eigen::VectorXd zero_;
 };
 

--- a/kdl_inverse_dynamics_solver/include/kdl_inverse_dynamics_solver/kdl_inverse_dynamics_solver.hpp
+++ b/kdl_inverse_dynamics_solver/include/kdl_inverse_dynamics_solver/kdl_inverse_dynamics_solver.hpp
@@ -18,7 +18,10 @@
 
 #include <string>
 #include <eigen3/Eigen/Core>
+#include <kdl/chain.hpp>
 #include <kdl/chaindynparam.hpp>
+#include <kdl/jntarray.hpp>
+#include <kdl/jntspaceinertiamatrix.hpp>
 #include <rclcpp/node_interfaces/node_parameters_interface.hpp>
 
 #include <inverse_dynamics_solver/inverse_dynamics_solver.hpp>
@@ -72,7 +75,15 @@ private:
   bool initialized_ = false;
   unsigned int number_of_joints_;
   KDL::Chain chain_;
-  std::shared_ptr<KDL::ChainDynParam> solver_;
+  std::unique_ptr<KDL::ChainDynParam> solver_;
+
+  // Kinematic/dynamic variables are allocated in the `initialize` method for real-time safeness; they are declared with smart pointers because all
+  // the methods in this class are `const`, and this would not allow changing their values if they were not declared with pointers
+  std::unique_ptr<KDL::JntArray> kdl_joint_positions_;
+  std::unique_ptr<KDL::JntArray> kdl_joint_velocities_;
+  std::unique_ptr<KDL::JntSpaceInertiaMatrix> H_;
+  std::unique_ptr<KDL::JntArray> c_;
+  std::unique_ptr<KDL::JntArray> g_;
 };
 
 }  // namespace kdl_inverse_dynamics_solver

--- a/kdl_inverse_dynamics_solver/include/kdl_inverse_dynamics_solver/kdl_inverse_dynamics_solver.hpp
+++ b/kdl_inverse_dynamics_solver/include/kdl_inverse_dynamics_solver/kdl_inverse_dynamics_solver.hpp
@@ -84,6 +84,7 @@ private:
   std::unique_ptr<KDL::JntSpaceInertiaMatrix> H_;
   std::unique_ptr<KDL::JntArray> c_;
   std::unique_ptr<KDL::JntArray> g_;
+  Eigen::VectorXd zero_;
 };
 
 }  // namespace kdl_inverse_dynamics_solver

--- a/kdl_inverse_dynamics_solver/src/kdl_inverse_dynamics_solver.cpp
+++ b/kdl_inverse_dynamics_solver/src/kdl_inverse_dynamics_solver.cpp
@@ -129,46 +129,37 @@ void InverseDynamicsSolverKDL::initialize(rclcpp::node_interfaces::NodeParameter
   initialized_ = true;
 
   // Allocate kinematic/dynamic variables once for real-time safeness
-  kdl_joint_positions_ = std::make_unique<KDL::JntArray>(number_of_joints_);
-  kdl_joint_velocities_ = std::make_unique<KDL::JntArray>(number_of_joints_);
-  H_ = std::make_unique<KDL::JntSpaceInertiaMatrix>(number_of_joints_);
-  c_ = std::make_unique<KDL::JntArray>(number_of_joints_);
-  g_ = std::make_unique<KDL::JntArray>(number_of_joints_);
+  kdl_joint_positions_ = KDL::JntArray(number_of_joints_);
+  kdl_joint_velocities_ = KDL::JntArray(number_of_joints_);
+  H_ = KDL::JntSpaceInertiaMatrix(number_of_joints_);
+  c_ = KDL::JntArray(number_of_joints_);
+  g_ = KDL::JntArray(number_of_joints_);
   zero_ = Eigen::VectorXd::Zero(number_of_joints_);
 }
 
 Eigen::MatrixXd InverseDynamicsSolverKDL::getInertiaMatrix(const Eigen::VectorXd& joint_positions) const
 {
   verifyInitialization_();
-
-  kdl_joint_positions_->data = joint_positions;
-
-  solver_->JntToMass(*kdl_joint_positions_, *H_);
-
-  return H_->data;
+  kdl_joint_positions_.data = joint_positions;
+  solver_->JntToMass(kdl_joint_positions_, H_);
+  return H_.data;
 }
 
 Eigen::VectorXd InverseDynamicsSolverKDL::getCoriolisVector(const Eigen::VectorXd& joint_positions, const Eigen::VectorXd& joint_velocities) const
 {
   verifyInitialization_();
-
-  kdl_joint_positions_->data = joint_positions;
-  kdl_joint_velocities_->data = joint_velocities;
-
-  solver_->JntToCoriolis(*kdl_joint_positions_, *kdl_joint_velocities_, *c_);
-
-  return c_->data;
+  kdl_joint_positions_.data = joint_positions;
+  kdl_joint_velocities_.data = joint_velocities;
+  solver_->JntToCoriolis(kdl_joint_positions_, kdl_joint_velocities_, c_);
+  return c_.data;
 }
 
 Eigen::VectorXd InverseDynamicsSolverKDL::getGravityVector(const Eigen::VectorXd& joint_positions) const
 {
   verifyInitialization_();
-
-  kdl_joint_positions_->data = joint_positions;
-
-  solver_->JntToGravity(*kdl_joint_positions_, *g_);
-
-  return g_->data;
+  kdl_joint_positions_.data = joint_positions;
+  solver_->JntToGravity(kdl_joint_positions_, g_);
+  return g_.data;
 }
 
 Eigen::VectorXd InverseDynamicsSolverKDL::getFrictionVector(const Eigen::VectorXd&) const

--- a/kdl_inverse_dynamics_solver/src/kdl_inverse_dynamics_solver.cpp
+++ b/kdl_inverse_dynamics_solver/src/kdl_inverse_dynamics_solver.cpp
@@ -20,8 +20,8 @@
 #include <inverse_dynamics_solver/exceptions.hpp>
 #include "kdl_inverse_dynamics_solver/kdl_inverse_dynamics_solver.hpp"
 
-using namespace kdl_inverse_dynamics_solver;
-
+namespace kdl_inverse_dynamics_solver
+{
 void InverseDynamicsSolverKDL::initialize(rclcpp::node_interfaces::NodeParametersInterface::ConstSharedPtr parameters_interface,
                                           const std::string& param_namespace, const std::string& robot_description)
 {
@@ -105,54 +105,51 @@ void InverseDynamicsSolverKDL::initialize(rclcpp::node_interfaces::NodeParameter
 
   // Instantiate the solver
   number_of_joints_ = chain_.getNrOfJoints();
-  solver_ = std::make_shared<KDL::ChainDynParam>(chain_, KDL::Vector(gravity[0], gravity[1], gravity[2]));
+  solver_ = std::make_unique<KDL::ChainDynParam>(chain_, KDL::Vector(gravity[0], gravity[1], gravity[2]));
 
   // Track plugin initialization
   initialized_ = true;
+
+  // Allocate kinematic/dynamic variables once for real-time safeness
+  kdl_joint_positions_ = std::make_unique<KDL::JntArray>(number_of_joints_);
+  kdl_joint_velocities_ = std::make_unique<KDL::JntArray>(number_of_joints_);
+  H_ = std::make_unique<KDL::JntSpaceInertiaMatrix>(number_of_joints_);
+  c_ = std::make_unique<KDL::JntArray>(number_of_joints_);
+  g_ = std::make_unique<KDL::JntArray>(number_of_joints_);
 }
 
 Eigen::MatrixXd InverseDynamicsSolverKDL::getInertiaMatrix(const Eigen::VectorXd& joint_positions) const
 {
   verifyInitialization_();
 
-  KDL::JntArray kdl_joint_positions(number_of_joints_);
-  KDL::JntSpaceInertiaMatrix H(number_of_joints_);
+  kdl_joint_positions_->data = joint_positions;
 
-  kdl_joint_positions.data = joint_positions;
+  solver_->JntToMass(*kdl_joint_positions_, *H_);
 
-  solver_->JntToMass(kdl_joint_positions, H);
-
-  return H.data;
+  return H_->data;
 }
 
 Eigen::VectorXd InverseDynamicsSolverKDL::getCoriolisVector(const Eigen::VectorXd& joint_positions, const Eigen::VectorXd& joint_velocities) const
 {
   verifyInitialization_();
 
-  KDL::JntArray kdl_joint_positions(number_of_joints_);
-  KDL::JntArray kdl_joint_velocities(number_of_joints_);
-  KDL::JntArray C(number_of_joints_);
+  kdl_joint_positions_->data = joint_positions;
+  kdl_joint_velocities_->data = joint_velocities;
 
-  kdl_joint_positions.data = joint_positions;
-  kdl_joint_velocities.data = joint_velocities;
+  solver_->JntToCoriolis(*kdl_joint_positions_, *kdl_joint_velocities_, *c_);
 
-  solver_->JntToCoriolis(kdl_joint_positions, kdl_joint_velocities, C);
-
-  return C.data;
+  return c_->data;
 }
 
 Eigen::VectorXd InverseDynamicsSolverKDL::getGravityVector(const Eigen::VectorXd& joint_positions) const
 {
   verifyInitialization_();
 
-  KDL::JntArray kdl_joint_positions(number_of_joints_);
-  KDL::JntArray g(number_of_joints_);
+  kdl_joint_positions_->data = joint_positions;
 
-  kdl_joint_positions.data = joint_positions;
+  solver_->JntToGravity(*kdl_joint_positions_, *g_);
 
-  solver_->JntToGravity(kdl_joint_positions, g);
-
-  return g.data;
+  return g_->data;
 }
 
 Eigen::VectorXd InverseDynamicsSolverKDL::getFrictionVector(const Eigen::VectorXd&) const
@@ -171,6 +168,7 @@ void InverseDynamicsSolverKDL::verifyInitialization_() const
     throw inverse_dynamics_solver::UninitializedException();
   }
 }
+}  // namespace kdl_inverse_dynamics_solver
 
 #include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(kdl_inverse_dynamics_solver::InverseDynamicsSolverKDL, inverse_dynamics_solver::InverseDynamicsSolver)

--- a/kdl_inverse_dynamics_solver/src/kdl_inverse_dynamics_solver.cpp
+++ b/kdl_inverse_dynamics_solver/src/kdl_inverse_dynamics_solver.cpp
@@ -116,6 +116,7 @@ void InverseDynamicsSolverKDL::initialize(rclcpp::node_interfaces::NodeParameter
   H_ = std::make_unique<KDL::JntSpaceInertiaMatrix>(number_of_joints_);
   c_ = std::make_unique<KDL::JntArray>(number_of_joints_);
   g_ = std::make_unique<KDL::JntArray>(number_of_joints_);
+  zero_.resize(number_of_joints_);
 }
 
 Eigen::MatrixXd InverseDynamicsSolverKDL::getInertiaMatrix(const Eigen::VectorXd& joint_positions) const
@@ -158,7 +159,7 @@ Eigen::VectorXd InverseDynamicsSolverKDL::getFrictionVector(const Eigen::VectorX
   // associated with joint frictions. In the future, this function could be implemented by
   // reading the friction coefficients present in the URDF.
   verifyInitialization_();
-  return Eigen::VectorXd::Zero(number_of_joints_);
+  return zero_;
 }
 
 void InverseDynamicsSolverKDL::verifyInitialization_() const

--- a/kdl_inverse_dynamics_solver/src/kdl_inverse_dynamics_solver.cpp
+++ b/kdl_inverse_dynamics_solver/src/kdl_inverse_dynamics_solver.cpp
@@ -116,7 +116,7 @@ void InverseDynamicsSolverKDL::initialize(rclcpp::node_interfaces::NodeParameter
   H_ = std::make_unique<KDL::JntSpaceInertiaMatrix>(number_of_joints_);
   c_ = std::make_unique<KDL::JntArray>(number_of_joints_);
   g_ = std::make_unique<KDL::JntArray>(number_of_joints_);
-  zero_.resize(number_of_joints_);
+  zero_ = Eigen::VectorXd::Zero(number_of_joints_);
 }
 
 Eigen::MatrixXd InverseDynamicsSolverKDL::getInertiaMatrix(const Eigen::VectorXd& joint_positions) const

--- a/ur10_inverse_dynamics_solver/CMakeLists.txt
+++ b/ur10_inverse_dynamics_solver/CMakeLists.txt
@@ -13,6 +13,12 @@ if(CMAKE_COMPILER_IS_GNUCXX
   )
 endif()
 
+# Code optimization flags are available here
+# https://clang.llvm.org/docs/CommandGuide/clang.html#code-generation-options
+set(CMAKE_CXX_FLAGS
+    "-O3"
+)
+
 # find dependencies
 find_package(ament_cmake REQUIRED)
 

--- a/ur10_inverse_dynamics_solver/include/ur10_inverse_dynamics_solver/ur10_inverse_dynamics_solver.hpp
+++ b/ur10_inverse_dynamics_solver/include/ur10_inverse_dynamics_solver/ur10_inverse_dynamics_solver.hpp
@@ -82,14 +82,23 @@ private:
    *
    * @return Returns a 6-by-1 vector with joint currents due to friction (expressed in [A])
    */
-  Eigen::VectorXd getFrictionCurrents_(const Eigen::VectorXd& joint_velocities) const;
+  Vector6d getFrictionCurrents_(const Vector6d& joint_velocities) const;
 
   /**
    * @brief This method returns the matrix K of motor drive gains, such that tau = K*i
    *
    * @return Returns a 6-by-6 diagonal matrix containing joint motor drive gains (expressed in [Nm/A]).
    */
-  Eigen::MatrixXd getDriveGainsMatrix_() const;
+  Matrix6d getDriveGainsMatrix_() const;
+
+  // Kinematic/dynamic variables are allocated in the `initialize` method for real-time safeness
+  double* q_;
+  double* qd_;
+  double* qdd_;
+  double* H_;
+  double* c_;
+  double* g_;
+  double* currents_;
 };
 
 }  // namespace ur10_inverse_dynamics_solver

--- a/ur10_inverse_dynamics_solver/include/ur10_inverse_dynamics_solver/ur10_inverse_dynamics_solver.hpp
+++ b/ur10_inverse_dynamics_solver/include/ur10_inverse_dynamics_solver/ur10_inverse_dynamics_solver.hpp
@@ -33,13 +33,12 @@ static const double K6 = 11.7682;
 static const unsigned short int NUMBER_OF_JOINTS = 6;
 typedef Eigen::Matrix<double, NUMBER_OF_JOINTS, 1> Vector6d;
 typedef Eigen::Matrix<double, NUMBER_OF_JOINTS, NUMBER_OF_JOINTS> Matrix6d;
+typedef Eigen::DiagonalMatrix<double, NUMBER_OF_JOINTS> DMatrix6d;
 
 class InverseDynamicsSolverUR10 : public inverse_dynamics_solver::InverseDynamicsSolver
 {
 public:
   InverseDynamicsSolverUR10() {}
-
-  ~InverseDynamicsSolverUR10();
 
   /**
    * @brief Refer to the superclass documentation
@@ -85,21 +84,12 @@ private:
    */
   Vector6d getFrictionCurrents_(const Vector6d& joint_velocities) const;
 
-  /**
-   * @brief This method returns the matrix K of motor drive gains, such that tau = K*i
-   *
-   * @return Returns a 6-by-6 diagonal matrix containing joint motor drive gains (expressed in [Nm/A]).
-   */
-  Matrix6d getDriveGainsMatrix_() const;
-
-  // Kinematic/dynamic variables are allocated in the `initialize` method for real-time safeness, and deallocated in the destructor
-  double* q_{ nullptr };
-  double* qd_{ nullptr };
-  double* qdd_{ nullptr };
-  double* H_{ nullptr };
-  double* c_{ nullptr };
-  double* g_{ nullptr };
-  double* currents_{ nullptr };
+  // Kinematic/dynamic variables are stack-allocated for real-time safeness: they are declared as mutable as they are output variables
+  mutable Matrix6d H_;
+  mutable Vector6d c_;
+  mutable Vector6d g_;
+  mutable Vector6d currents_;
+  DMatrix6d K_{ (Vector6d() << K1, K2, K3, K4, K5, K6).finished() };
 };
 
 }  // namespace ur10_inverse_dynamics_solver

--- a/ur10_inverse_dynamics_solver/include/ur10_inverse_dynamics_solver/ur10_inverse_dynamics_solver.hpp
+++ b/ur10_inverse_dynamics_solver/include/ur10_inverse_dynamics_solver/ur10_inverse_dynamics_solver.hpp
@@ -84,7 +84,7 @@ private:
    */
   Vector6d getFrictionCurrents_(const Vector6d& joint_velocities) const;
 
-  // Kinematic/dynamic variables are stack-allocated for real-time safeness: they are declared as mutable as they are output variables
+  // These variables are stack-allocated for real-time safeness: they are declared as mutable as they are output variables
   mutable Matrix6d H_;
   mutable Vector6d c_;
   mutable Vector6d g_;

--- a/ur10_inverse_dynamics_solver/include/ur10_inverse_dynamics_solver/ur10_inverse_dynamics_solver.hpp
+++ b/ur10_inverse_dynamics_solver/include/ur10_inverse_dynamics_solver/ur10_inverse_dynamics_solver.hpp
@@ -39,6 +39,8 @@ class InverseDynamicsSolverUR10 : public inverse_dynamics_solver::InverseDynamic
 public:
   InverseDynamicsSolverUR10() {}
 
+  ~InverseDynamicsSolverUR10();
+
   /**
    * @brief Refer to the superclass documentation
    *
@@ -90,14 +92,14 @@ private:
    */
   Matrix6d getDriveGainsMatrix_() const;
 
-  // Kinematic/dynamic variables are allocated in the `initialize` method for real-time safeness
-  double* q_;
-  double* qd_;
-  double* qdd_;
-  double* H_;
-  double* c_;
-  double* g_;
-  double* currents_;
+  // Kinematic/dynamic variables are allocated in the `initialize` method for real-time safeness, and deallocated in the destructor
+  double* q_{ nullptr };
+  double* qd_{ nullptr };
+  double* qdd_{ nullptr };
+  double* H_{ nullptr };
+  double* c_{ nullptr };
+  double* g_{ nullptr };
+  double* currents_{ nullptr };
 };
 
 }  // namespace ur10_inverse_dynamics_solver

--- a/ur10_inverse_dynamics_solver/src/ur10_inverse_dynamics_solver.cpp
+++ b/ur10_inverse_dynamics_solver/src/ur10_inverse_dynamics_solver.cpp
@@ -20,64 +20,60 @@
 #include "ur10_inverse_dynamics_solver/getCurrents.hpp"
 #include "ur10_inverse_dynamics_solver/ur10_inverse_dynamics_solver.hpp"
 
-using namespace ur10_inverse_dynamics_solver;
+namespace ur10_inverse_dynamics_solver
 
+{
 void InverseDynamicsSolverUR10::initialize(rclcpp::node_interfaces::NodeParametersInterface::ConstSharedPtr, const std::string&, const std::string&)
-{}
+{
+  // Allocate kinematic/dynamic variables once for real-time safeness
+  q_ = (double*)malloc(NUMBER_OF_JOINTS * sizeof(double));
+  qd_ = (double*)malloc(NUMBER_OF_JOINTS * sizeof(double));
+  qdd_ = (double*)malloc(NUMBER_OF_JOINTS * sizeof(double));
+  H_ = (double*)malloc(NUMBER_OF_JOINTS * NUMBER_OF_JOINTS * sizeof(double));
+  c_ = (double*)malloc(NUMBER_OF_JOINTS * sizeof(double));
+  g_ = (double*)malloc(NUMBER_OF_JOINTS * sizeof(double));
+  currents_ = (double*)malloc(NUMBER_OF_JOINTS * sizeof(double));
+}
 
 Eigen::MatrixXd InverseDynamicsSolverUR10::getInertiaMatrix(const Eigen::VectorXd& joint_positions) const
 {
-  double q[NUMBER_OF_JOINTS];
-  double B[NUMBER_OF_JOINTS * NUMBER_OF_JOINTS];
-  Vector6d::Map(q) = joint_positions;
-  getInertiaCurrents(q, B);
-  return getDriveGainsMatrix_() * Matrix6d(B);
+  Vector6d::Map(q_) = joint_positions;
+  getInertiaCurrents(q_, H_);
+  return getDriveGainsMatrix_() * Matrix6d(H_);
 }
 
 Eigen::VectorXd InverseDynamicsSolverUR10::getCoriolisVector(const Eigen::VectorXd& joint_positions, const Eigen::VectorXd& joint_velocities) const
 {
-  double q[NUMBER_OF_JOINTS];
-  double qd[NUMBER_OF_JOINTS];
-  double coriolis_currents[NUMBER_OF_JOINTS];
-  Vector6d::Map(q) = joint_positions;
-  Vector6d::Map(qd) = joint_velocities;
-  getCoriolisCurrents(q, qd, coriolis_currents);
-  return getDriveGainsMatrix_() * Vector6d(coriolis_currents);
+  Vector6d::Map(q_) = joint_positions;
+  Vector6d::Map(qd_) = joint_velocities;
+  getCoriolisCurrents(q_, qd_, c_);
+  return getDriveGainsMatrix_() * Vector6d(c_);
 }
 
 Eigen::VectorXd InverseDynamicsSolverUR10::getGravityVector(const Eigen::VectorXd& joint_positions) const
 {
-  double q[NUMBER_OF_JOINTS];
-  double gravity_currents[NUMBER_OF_JOINTS];
-  Vector6d::Map(q) = joint_positions;
-  getGravityCurrents(q, gravity_currents);
-  return getDriveGainsMatrix_() * Vector6d(gravity_currents);
+  Vector6d::Map(q_) = joint_positions;
+  getGravityCurrents(q_, g_);
+  return getDriveGainsMatrix_() * Vector6d(g_);
 }
 
-Eigen::VectorXd InverseDynamicsSolverUR10::getFrictionVector(const Eigen::VectorXd& qd) const
+Eigen::VectorXd InverseDynamicsSolverUR10::getFrictionVector(const Eigen::VectorXd& joint_velocities) const
 {
-  return getDriveGainsMatrix_() * getFrictionCurrents_(qd);
+  return getDriveGainsMatrix_() * getFrictionCurrents_(joint_velocities);
 }
 
 Eigen::VectorXd InverseDynamicsSolverUR10::getTorques(const Eigen::VectorXd& joint_positions, const Eigen::VectorXd& joint_velocities,
                                                       const Eigen::VectorXd& joint_accelerations) const
 {
-  double q[NUMBER_OF_JOINTS];
-  double qd[NUMBER_OF_JOINTS];
-  double qdd[NUMBER_OF_JOINTS];
-  double currents[NUMBER_OF_JOINTS];
-  Vector6d::Map(q) = joint_positions;
-  Vector6d::Map(qd) = joint_velocities;
-  Vector6d::Map(qdd) = joint_accelerations;
-  getCurrents(q, qd, qdd, currents);
-  return getDriveGainsMatrix_() * Vector6d(currents) + getFrictionVector(joint_velocities);
+  Vector6d::Map(q_) = joint_positions;
+  Vector6d::Map(qd_) = joint_velocities;
+  Vector6d::Map(qdd_) = joint_accelerations;
+  getCurrents(q_, qd_, qdd_, currents_);
+  return getDriveGainsMatrix_() * Vector6d(currents_) + getFrictionVector(joint_velocities);
 }
 
-Eigen::VectorXd InverseDynamicsSolverUR10::getFrictionCurrents_(const Eigen::VectorXd& joint_velocities) const
+Vector6d InverseDynamicsSolverUR10::getFrictionCurrents_(const Vector6d& joint_velocities) const
 {
-  // friction current vector
-  Vector6d friction_current_vector;
-
   // parameters of the sigmoid friction model
   Vector6d f_v;
   Vector6d f_o;
@@ -120,17 +116,17 @@ Eigen::VectorXd InverseDynamicsSolverUR10::getFrictionCurrents_(const Eigen::Vec
   ni(4) = -0.011778095526897;
   ni(5) = -0.012953200294568;
 
-  for (long int i = 0; i < joint_velocities.size(); ++i)  // The 'long int' type is to suppress the [-Wsign-compare] warning
-    friction_current_vector(i) = f_v(i) * joint_velocities(i) + f_o(i) + f_c(i) / (1 + exp(-alpha(i) * (joint_velocities(i) + ni(i))));
-
-  return friction_current_vector;
+  return f_v.cwiseProduct(joint_velocities) + f_o +
+         f_c.cwiseQuotient(Vector6d::Ones() + (-alpha.cwiseProduct(joint_velocities + ni)).array().exp().matrix());
 }
 
-Eigen::MatrixXd InverseDynamicsSolverUR10::getDriveGainsMatrix_() const
+Matrix6d InverseDynamicsSolverUR10::getDriveGainsMatrix_() const
 {
-  std::vector<double> drive_gains_vector{ K1, K2, K3, K4, K5, K6 };
-  return Vector6d(drive_gains_vector.data()).asDiagonal();
+  Vector6d drive_gains_vector;
+  drive_gains_vector << K1, K2, K3, K4, K5, K6;
+  return drive_gains_vector.asDiagonal();
 }
+}  // namespace ur10_inverse_dynamics_solver
 
 #include <pluginlib/class_list_macros.hpp>
 PLUGINLIB_EXPORT_CLASS(ur10_inverse_dynamics_solver::InverseDynamicsSolverUR10, inverse_dynamics_solver::InverseDynamicsSolver)

--- a/ur10_inverse_dynamics_solver/src/ur10_inverse_dynamics_solver.cpp
+++ b/ur10_inverse_dynamics_solver/src/ur10_inverse_dynamics_solver.cpp
@@ -23,64 +23,37 @@
 namespace ur10_inverse_dynamics_solver
 {
 
-InverseDynamicsSolverUR10::~InverseDynamicsSolverUR10()
-{
-  delete[] q_;
-  delete[] qd_;
-  delete[] qdd_;
-  delete[] H_;
-  delete[] c_;
-  delete[] g_;
-  delete[] currents_;
-}
-
 void InverseDynamicsSolverUR10::initialize(rclcpp::node_interfaces::NodeParametersInterface::ConstSharedPtr, const std::string&, const std::string&)
-{
-  // Allocate kinematic/dynamic variables once for real-time safeness
-  q_ = new double[NUMBER_OF_JOINTS];
-  qd_ = new double[NUMBER_OF_JOINTS];
-  qdd_ = new double[NUMBER_OF_JOINTS];
-  H_ = new double[NUMBER_OF_JOINTS * NUMBER_OF_JOINTS];
-  c_ = new double[NUMBER_OF_JOINTS];
-  g_ = new double[NUMBER_OF_JOINTS];
-  currents_ = new double[NUMBER_OF_JOINTS];
-}
+{}
 
 Eigen::MatrixXd InverseDynamicsSolverUR10::getInertiaMatrix(const Eigen::VectorXd& joint_positions) const
 {
-  Vector6d::Map(q_) = joint_positions;
-  getInertiaCurrents(q_, H_);
-  return getDriveGainsMatrix_() * Matrix6d(H_);
+  getInertiaCurrents(joint_positions.data(), H_.data());
+  return K_ * H_;
 }
 
 Eigen::VectorXd InverseDynamicsSolverUR10::getCoriolisVector(const Eigen::VectorXd& joint_positions, const Eigen::VectorXd& joint_velocities) const
 {
-  Vector6d::Map(q_) = joint_positions;
-  Vector6d::Map(qd_) = joint_velocities;
-  getCoriolisCurrents(q_, qd_, c_);
-  return getDriveGainsMatrix_() * Vector6d(c_);
+  getCoriolisCurrents(joint_positions.data(), joint_velocities.data(), c_.data());
+  return K_ * c_;
 }
 
 Eigen::VectorXd InverseDynamicsSolverUR10::getGravityVector(const Eigen::VectorXd& joint_positions) const
 {
-  Vector6d::Map(q_) = joint_positions;
-  getGravityCurrents(q_, g_);
-  return getDriveGainsMatrix_() * Vector6d(g_);
+  getGravityCurrents(joint_positions.data(), g_.data());
+  return K_ * g_;
 }
 
 Eigen::VectorXd InverseDynamicsSolverUR10::getFrictionVector(const Eigen::VectorXd& joint_velocities) const
 {
-  return getDriveGainsMatrix_() * getFrictionCurrents_(joint_velocities);
+  return K_ * getFrictionCurrents_(joint_velocities);
 }
 
 Eigen::VectorXd InverseDynamicsSolverUR10::getTorques(const Eigen::VectorXd& joint_positions, const Eigen::VectorXd& joint_velocities,
                                                       const Eigen::VectorXd& joint_accelerations) const
 {
-  Vector6d::Map(q_) = joint_positions;
-  Vector6d::Map(qd_) = joint_velocities;
-  Vector6d::Map(qdd_) = joint_accelerations;
-  getCurrents(q_, qd_, qdd_, currents_);
-  return getDriveGainsMatrix_() * Vector6d(currents_) + getFrictionVector(joint_velocities);
+  getCurrents(joint_positions.data(), joint_velocities.data(), joint_accelerations.data(), currents_.data());
+  return K_ * currents_ + getFrictionVector(joint_velocities);
 }
 
 Vector6d InverseDynamicsSolverUR10::getFrictionCurrents_(const Vector6d& joint_velocities) const
@@ -129,13 +102,6 @@ Vector6d InverseDynamicsSolverUR10::getFrictionCurrents_(const Vector6d& joint_v
 
   return f_v.cwiseProduct(joint_velocities) + f_o +
          f_c.cwiseQuotient(Vector6d::Ones() + (-alpha.cwiseProduct(joint_velocities + ni)).array().exp().matrix());
-}
-
-Matrix6d InverseDynamicsSolverUR10::getDriveGainsMatrix_() const
-{
-  Vector6d drive_gains_vector;
-  drive_gains_vector << K1, K2, K3, K4, K5, K6;
-  return drive_gains_vector.asDiagonal();
 }
 }  // namespace ur10_inverse_dynamics_solver
 

--- a/ur10_inverse_dynamics_solver/src/ur10_inverse_dynamics_solver.cpp
+++ b/ur10_inverse_dynamics_solver/src/ur10_inverse_dynamics_solver.cpp
@@ -21,18 +21,29 @@
 #include "ur10_inverse_dynamics_solver/ur10_inverse_dynamics_solver.hpp"
 
 namespace ur10_inverse_dynamics_solver
-
 {
+
+InverseDynamicsSolverUR10::~InverseDynamicsSolverUR10()
+{
+  delete[] q_;
+  delete[] qd_;
+  delete[] qdd_;
+  delete[] H_;
+  delete[] c_;
+  delete[] g_;
+  delete[] currents_;
+}
+
 void InverseDynamicsSolverUR10::initialize(rclcpp::node_interfaces::NodeParametersInterface::ConstSharedPtr, const std::string&, const std::string&)
 {
   // Allocate kinematic/dynamic variables once for real-time safeness
-  q_ = (double*)malloc(NUMBER_OF_JOINTS * sizeof(double));
-  qd_ = (double*)malloc(NUMBER_OF_JOINTS * sizeof(double));
-  qdd_ = (double*)malloc(NUMBER_OF_JOINTS * sizeof(double));
-  H_ = (double*)malloc(NUMBER_OF_JOINTS * NUMBER_OF_JOINTS * sizeof(double));
-  c_ = (double*)malloc(NUMBER_OF_JOINTS * sizeof(double));
-  g_ = (double*)malloc(NUMBER_OF_JOINTS * sizeof(double));
-  currents_ = (double*)malloc(NUMBER_OF_JOINTS * sizeof(double));
+  q_ = new double[NUMBER_OF_JOINTS];
+  qd_ = new double[NUMBER_OF_JOINTS];
+  qdd_ = new double[NUMBER_OF_JOINTS];
+  H_ = new double[NUMBER_OF_JOINTS * NUMBER_OF_JOINTS];
+  c_ = new double[NUMBER_OF_JOINTS];
+  g_ = new double[NUMBER_OF_JOINTS];
+  currents_ = new double[NUMBER_OF_JOINTS];
 }
 
 Eigen::MatrixXd InverseDynamicsSolverUR10::getInertiaMatrix(const Eigen::VectorXd& joint_positions) const


### PR DESCRIPTION
This PR enforces real-time safeness by avoiding dynamic allocations of arrays.

**Note:** the Franka-INRIA solver is not changed for two reasons:
1. We are not the original authors of the solver, so I'd like a feedback before applying such changes
2. Internally, the methods already use fixed-size arrays, so the compiler might already optimize the code in this sense 