### PR TITLE
Don't depend on Python 2 argparse

### DIFF
--- a/franka_inria_inverse_dynamics_solver/CMakeLists.txt
+++ b/franka_inria_inverse_dynamics_solver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 project(franka_inria_inverse_dynamics_solver)
 
 if(CMAKE_COMPILER_IS_GNUCXX

--- a/inverse_dynamics_solver/package.xml
+++ b/inverse_dynamics_solver/package.xml
@@ -20,7 +20,6 @@
   <depend>sensor_msgs</depend>
   <depend>urdf</depend>
 
-  <exec_depend>python-argparse</exec_depend>
   <exec_depend>python3-matplotlib</exec_depend>
   <exec_depend>python3-numpy</exec_depend>
   <exec_depend>python3-tabulate</exec_depend>

--- a/inverse_dynamics_solver/scripts/plot_joint_state.py
+++ b/inverse_dynamics_solver/scripts/plot_joint_state.py
@@ -45,7 +45,7 @@ def read_ros2_bag(bag_file, topic):
 
     messages = []
     while reader.has_next():
-        (topic_name, data, t) = reader.read_next()
+        (topic_name, data, _, _) = reader.read_next_ext()
         if topic_name == topic:
             msg = deserialize_message(data, JointState)
             messages.append(msg)

--- a/kdl_inverse_dynamics_solver/CMakeLists.txt
+++ b/kdl_inverse_dynamics_solver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 project(kdl_inverse_dynamics_solver)
 
 if(CMAKE_COMPILER_IS_GNUCXX

--- a/ur10_inverse_dynamics_solver/CMakeLists.txt
+++ b/ur10_inverse_dynamics_solver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 project(ur10_inverse_dynamics_solver)
 
 if(CMAKE_COMPILER_IS_GNUCXX


### PR DESCRIPTION
It's rosdep entry is going to be removed. See https://github.com/ros/rosdistro/issues/51715.

argparse is in Python 3 standard library so it doesn't need to be referenced explicitly.